### PR TITLE
[DRUPAL] Display year in news/blog/article pages ONLINE-568

### DIFF
--- a/www/www.reactos.org/sites/all/themes/Porto_sub/node/node--article.tpl.php
+++ b/www/www.reactos.org/sites/all/themes/Porto_sub/node/node--article.tpl.php
@@ -97,7 +97,7 @@ $nodevisit=statistics_get($node->nid);
                                 <?php if ($display_submitted): ?>
                                 <div class="date">
                                     <span class="day"><?php print format_date($node->created, 'custom', 'd'); ?></span>
-                                    <?php print t(format_date($node->created, 'custom', 'M')); ?>
+                                    <?php print t(format_date($node->created, 'custom', 'M Y')); ?>
                                 </div>
                                 <?php endif; ?>	
                         </div>

--- a/www/www.reactos.org/sites/all/themes/Porto_sub/node/node--blog.tpl.php
+++ b/www/www.reactos.org/sites/all/themes/Porto_sub/node/node--blog.tpl.php
@@ -95,7 +95,7 @@ $nodevisit=statistics_get($node->nid);
             <?php if ($display_submitted): ?>
             <div class="date">
                 <span class="day"><?php print format_date($node->created, 'custom', 'd'); ?></span>
-                <?php print t(format_date($node->created, 'custom', 'M')); ?>
+                <?php print t(format_date($node->created, 'custom', 'M Y')); ?>
             </div>
             <div class="post-data">
                 <span class="icon visits"></span>

--- a/www/www.reactos.org/sites/all/themes/Porto_sub/node/node--news.tpl.php
+++ b/www/www.reactos.org/sites/all/themes/Porto_sub/node/node--news.tpl.php
@@ -95,7 +95,7 @@ $nodevisit=statistics_get($node->nid);
             <?php if ($display_submitted): ?>
             <div class="date">
                 <span class="day"><?php print format_date($node->created, 'custom', 'd'); ?></span>
-                <?php print t(format_date($node->created, 'custom', 'M')); ?>
+                <?php print t(format_date($node->created, 'custom', 'M Y')); ?>
             </div>
             <div class="post-data">
                 <span class="icon visits"></span>


### PR DESCRIPTION
@ColinFinck When you open the article from search, it is impossible to find what year this article was posted. I am unable to test it, but I checked existing code on year formatting.

![image](https://user-images.githubusercontent.com/4127660/40083658-21f23cf2-5852-11e8-9a7d-1d1342494b15.png)
