### PR TITLE
[GETBUILDS] Disable MSVC builds filter by default ONLINE-772

### DIFF
--- a/www/www.reactos.org/getbuilds/config.inc.php
+++ b/www/www.reactos.org/getbuilds/config.inc.php
@@ -19,10 +19,10 @@
 	);
 
 	$SUFFIXES = array(
-		"-x86-gcc-lin-dbg" => "x86 GCC Debug",
-		"-x86-gcc-lin-rel" => "x86 GCC Release",
-		"-x86-msvc-win-dbg" => "x86 MSVC Debug",
-		"-x64-msvc-win-dbg" => "x64 MSVC Debug",
+		"-x86-gcc-lin-dbg" => array("x86 GCC Debug", TRUE),
+		"-x86-gcc-lin-rel" => array("x86 GCC Release", TRUE),
+		"-x86-msvc-win-dbg" => array("x86 MSVC Debug", FALSE),
+		"-x64-msvc-win-dbg" => array("x64 MSVC Debug", FALSE),
 	);
 
 	$SVN_PREFIX_TRANSLATIONS = array(

--- a/www/www.reactos.org/getbuilds/index.php
+++ b/www/www.reactos.org/getbuilds/index.php
@@ -104,7 +104,7 @@
 					<div class="col-sm-3">
 						<?php
 							foreach ($SUFFIXES as $k => $v)
-								printf('<div class="checkbox"><label><input type="checkbox" name="suffixes" id="%s" checked="checked"> %s</label></div>', $k, $v);
+								printf('<div class="checkbox"><label><input type="checkbox" name="suffixes" id="%s" %s> %s</label></div>', $k, $v[1] == TRUE ? 'checked="checked"' : '', $v[0]);
 						?>
 					</div>
 				</div>


### PR DESCRIPTION
@ColinFinck Disables rendering of `checked="checked"` attribute on the MSVC filters. 
