### PR TITLE
[ROSLOGIN] Check for empty redirect field in login POST query

### DIFF
--- a/www/www.reactos.org/roslogin/actions/LoginAction.php
+++ b/www/www.reactos.org/roslogin/actions/LoginAction.php
@@ -25,7 +25,7 @@
 				}
 
 				// Redirect to the given URL or to the Self-Service if there is none.
-				if (array_key_exists("redirect", $_POST))
+				if (array_key_exists("redirect", $_POST) && !empty($_POST["redirect"]))
 					redirect_to($_POST["redirect"]);
 				else
 					redirect_to("?p=selfservice");


### PR DESCRIPTION
This should fix [ONLINE-793](https://jira.reactos.org/browse/ONLINE-793).