### PR TITLE
[TESTMAN] Unblacklist 5 blacklisted tests

### DIFF
--- a/www/www.reactos.org/testman/blacklist.txt
+++ b/www/www.reactos.org/testman/blacklist.txt
@@ -1,13 +1,10 @@
 // Contains blacklisted test suites in a form of module:testname
 
 kernel32:loader
-kernel32:mailslot
 msi:msi
 
 // number of tests/failures depends on the number of running processes which may vary between runs
 ntdll:info
-
-quartz:referenceclock
 
 // (Alex: is wildly random/erratic, I believe due to ws2_32:sock)
 urlmon:url
@@ -21,12 +18,8 @@ user32:win
 wininet:http
 ws2_32:sock 
 
-quartz:filtermapper
-
 // Blacklist on Amine's request
 gdi32:bitmap
-gdiplus:graphicspath
-gdiplus:region
 msxml3:xmlview
 urlmon:protocol
 user32:menu


### PR DESCRIPTION
They all seem to be 100% green over several successive runs: On all: releases/0.4.14, releases/0.4.15, master head, and also the x86 WHS, and also "Test Win2003_x64":
**gdiplus:graphicspath
gdiplus:region
kernel32:mailslot
quartz:filtermapper
quartz:referenceclock**

VBox master head vs 0.4.14-release-123-gcc9c2ba
https://reactos.org/testman/compare.php?ids=97823,97827

KVM master head vs 0.4.14-release-123-gcc9c2ba
https://reactos.org/testman/compare.php?ids=97822,97828

WHS (x86):
https://reactos.org/testman/compare.php?ids=97640

Test Win2003_x64:
https://reactos.org/testman/compare.php?ids=97952